### PR TITLE
First try for the mcp skimmer

### DIFF
--- a/include/MCP_Skimmer.h
+++ b/include/MCP_Skimmer.h
@@ -44,11 +44,14 @@ public:
     /* Check if MCP started in tracker */
     bool hasOrigininTracker(TVector3 point);
 
+    /* Check if MCP decayed in calo */
+    bool hasDecayedinCalo(TVector3 point);
+
     /* Check if the mcp is a backscatter */
     bool isBackscatter(TVector3 spoint, TVector3 epoint);
 
-    /* Check if it is a breamstrahlung photon */
-    bool isBreamstrahlung(TVector3 point, int pdg, int motherpdg);
+    /* Check if it is a Bremsstrahlung photon */
+    bool isBremsstrahlung(TVector3 point, int pdg, int motherpdg);
 
 protected:
 

--- a/include/MCP_Skimmer.h
+++ b/include/MCP_Skimmer.h
@@ -5,6 +5,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "TVector3.h"
 
 class MCP_Skimmer
 {
@@ -39,6 +40,15 @@ public:
 
     /* Method to clear the event variables */
     void ClearVectors();
+
+    /* Check if MCP started in tracker */
+    bool hasOrigininTracker(TVector3 point);
+
+    /* Check if the mcp is a backscatter */
+    bool isBackscatter(TVector3 spoint, TVector3 epoint);
+
+    /* Check if it is a breamstrahlung photon */
+    bool isBreamstrahlung(TVector3 point, int pdg, int motherpdg);
 
 protected:
 
@@ -95,6 +105,9 @@ private:
     std::vector<float>   _TrajMCPY;
     std::vector<float>   _TrajMCPZ;
     std::vector<int>     _TrajMCPTrajIndex;
+
+    //vector of pdg values where we should keep the daughter
+    std::vector<int> daughtersToKeep = {22, 111, 310, 13, 211, 321};
 };
 
 #endif /* MCP_SKIMMER_H */

--- a/src/CAF.cpp
+++ b/src/CAF.cpp
@@ -406,9 +406,8 @@ void CAF::loop()
         {
             //Get the creating process
             std::string mcp_process = MCPProc->at(i);
-
-            //Need to check what kind of particle?
-            // if(mcp_process != "primary") continue;
+            //Get ending process
+            std::string mcp_endprocess = MCPEndProc->at(i);
 
             nFSP++;
 
@@ -481,6 +480,25 @@ void CAF::loop()
                     float ereco = rando->Gaus( std::sqrt(ptrue*ptrue + neutron_mass*neutron_mass), sigmaNeutronECAL_first );
                     erecon.push_back(ereco > 0 ? ereco : 0.);
                     // std::cout << "true part n true energy " << std::sqrt(ptrue*ptrue + neutron_mass*neutron_mass) << " ereco " << erecon[i] << std::endl;
+                    truepdg.push_back(pdg);
+                    truepx.push_back(MCPStartPX->at(i));
+                    truepy.push_back(MCPStartPY->at(i));
+                    truepz.push_back(MCPStartPZ->at(i));
+                    _MCPStartX.push_back(MCPStartX->at(i));
+                    _MCPStartY.push_back(MCPStartY->at(i));
+                    _MCPStartZ.push_back(MCPStartZ->at(i));
+                    _MCPEndX.push_back(MCPEndX->at(i));
+                    _MCPEndY.push_back(MCPEndY->at(i));
+                    _MCPEndZ.push_back(MCPEndZ->at(i));
+                    mother.push_back(Mother->at(i));
+                    pdgmother.push_back(PDGMother->at(i));
+                    // save the true momentum
+                    truep.push_back(ptrue);
+                    // save the true angle
+                    _angle.push_back(angle);
+                    //Save MC process
+                    _MCProc.push_back(mcp_process);
+                    _MCEndProc.push_back(mcp_endprocess);
                 }
             }
 
@@ -491,12 +509,32 @@ void CAF::loop()
                 float ereco = rando->Gaus( std::sqrt(ptrue*ptrue + pi0_mass*pi0_mass), ECAL_pi0_resolution*std::sqrt(ptrue*ptrue + pi0_mass*pi0_mass));
                 erecon.push_back(ereco);
                 recopid.push_back(111);
+
+                truepdg.push_back(pdg);
+                truepx.push_back(MCPStartPX->at(i));
+                truepy.push_back(MCPStartPY->at(i));
+                truepz.push_back(MCPStartPZ->at(i));
+                _MCPStartX.push_back(MCPStartX->at(i));
+                _MCPStartY.push_back(MCPStartY->at(i));
+                _MCPStartZ.push_back(MCPStartZ->at(i));
+                _MCPEndX.push_back(MCPEndX->at(i));
+                _MCPEndY.push_back(MCPEndY->at(i));
+                _MCPEndZ.push_back(MCPEndZ->at(i));
+                mother.push_back(Mother->at(i));
+                pdgmother.push_back(PDGMother->at(i));
+                // save the true momentum
+                truep.push_back(ptrue);
+                // save the true angle
+                _angle.push_back(angle);
+                //Save MC process
+                _MCProc.push_back(mcp_process);
+                _MCEndProc.push_back(mcp_endprocess);
             }
 
             //for gammas
             if(pdg == 22)
             {
-                //TODO check if they are not from a pi0 or decayed in the TPC
+                //TODO check if they are not from a pi0 or decayed in the TPC and hit the ECAL!
                 if( PDGMother->at(i) != 111 )
                 {
                     TVector3 point(MCPEndX->at(i), MCPEndY->at(i), MCPEndZ->at(i));
@@ -507,6 +545,26 @@ void CAF::loop()
                         float ereco = rando->Gaus(ptrue, ECAL_resolution);
                         erecon.push_back(ereco);
                         recopid.push_back(22);
+
+                        truepdg.push_back(pdg);
+                        truepx.push_back(MCPStartPX->at(i));
+                        truepy.push_back(MCPStartPY->at(i));
+                        truepz.push_back(MCPStartPZ->at(i));
+                        _MCPStartX.push_back(MCPStartX->at(i));
+                        _MCPStartY.push_back(MCPStartY->at(i));
+                        _MCPStartZ.push_back(MCPStartZ->at(i));
+                        _MCPEndX.push_back(MCPEndX->at(i));
+                        _MCPEndY.push_back(MCPEndY->at(i));
+                        _MCPEndZ.push_back(MCPEndZ->at(i));
+                        mother.push_back(Mother->at(i));
+                        pdgmother.push_back(PDGMother->at(i));
+                        // save the true momentum
+                        truep.push_back(ptrue);
+                        // save the true angle
+                        _angle.push_back(angle);
+                        //Save MC process
+                        _MCProc.push_back(mcp_process);
+                        _MCEndProc.push_back(mcp_endprocess);
                     }
                 }
             }
@@ -536,9 +594,6 @@ void CAF::loop()
                 truep.push_back(ptrue);
                 // save the true angle
                 _angle.push_back(angle);
-
-                //Get ending process
-                std::string mcp_endprocess = MCPEndProc->at(i);
                 //Save MC process
                 _MCProc.push_back(mcp_process);
                 _MCEndProc.push_back(mcp_endprocess);

--- a/src/MCP_Skimmer.cpp
+++ b/src/MCP_Skimmer.cpp
@@ -332,9 +332,9 @@ void MCP_Skimmer::SkimMCParticle()
                     std::cout << " Origin in tracker " << hasOrigininTracker(spoint) << std::endl;
                     IndexesToKeep.push_back(i);
                 }
-                //if breamstrahlung photon
-                else if ( isBreamstrahlung(spoint, PDG->at(i), PDGMother->at(i)) && process == "eBrem" ) {
-                    std::cout << "Keeping Breamstrahlung" << std::endl;
+                //if Bremsstrahlung photon
+                else if ( isBremsstrahlung(spoint, PDG->at(i), PDGMother->at(i)) && process == "eBrem" ) {
+                    std::cout << "Keeping Bremsstrahlung" << std::endl;
                     std::cout << "Index " << i << " TrkID " << MCPTrkID->at(i) << " pdg " << PDG->at(i) << " mother pdg " << PDGMother->at(i);
                     std::cout << " process " << process << std::endl;
                     std::cout << " Start point X: " << spoint.X() << " Y: " << spoint.Y() << " Z: " << spoint.Z() << std::endl;
@@ -503,6 +503,11 @@ bool MCP_Skimmer::hasOrigininTracker(TVector3 point)
     return hasOrigininTracker;
 }
 
+bool MCP_Skimmer::hasDecayedinCalo(TVector3 point)
+{
+    return !hasOrigininTracker(point);
+}
+
 bool MCP_Skimmer::isBackscatter(TVector3 spoint, TVector3 epoint)
 {
     bool isBackscatter = false;
@@ -519,12 +524,12 @@ bool MCP_Skimmer::isBackscatter(TVector3 spoint, TVector3 epoint)
     return isBackscatter;
 }
 
-bool MCP_Skimmer::isBreamstrahlung(TVector3 point, int pdg, int motherpdg)
+bool MCP_Skimmer::isBremsstrahlung(TVector3 point, int pdg, int motherpdg)
 {
-    bool isBreamstrahlung = false;
+    bool isBremsstrahlung = false;
 
     //Check if it has origin in the tracker and that the pdg is photon and mother is electron/positron (most probable)
-    if(hasOrigininTracker(point) && pdg == 22 && std::abs(motherpdg) == 11) isBreamstrahlung = true;
+    if(hasOrigininTracker(point) && pdg == 22 && std::abs(motherpdg) == 11) isBremsstrahlung = true;
 
-    return isBreamstrahlung;
+    return isBremsstrahlung;
 }

--- a/src/MCP_Skimmer.cpp
+++ b/src/MCP_Skimmer.cpp
@@ -301,6 +301,11 @@ void MCP_Skimmer::SkimMCParticle()
         //Check which indexes to keep
         for(int i = 0; i < MCPStartPX->size(); i++)
         {
+            TVector3 spoint(MCPStartX->at(i), MCPStartY->at(i), MCPStartZ->at(i));//start point
+            TVector3 epoint(MCPEndX->at(i), MCPEndY->at(i), MCPEndZ->at(i));//end point
+            std::string process = MCPProc->at(i);
+            std::string endprocess = MCPEndProc->at(i);
+
             //found a particle that has already an ancestor
             if( mcp_kid_mother_map.find(MCPTrkID->at(i)) !=  mcp_kid_mother_map.end() )
             {
@@ -309,37 +314,37 @@ void MCP_Skimmer::SkimMCParticle()
                 // - backscatters from calo to tracker important for background
                 // - breamstrahlung photons / delta rays
 
-                TVector3 spoint(MCPStartX->at(i), MCPStartY->at(i), MCPStartZ->at(i));//start point
-                TVector3 epoint(MCPEndX->at(i), MCPEndY->at(i), MCPEndZ->at(i));//end point
-                std::string process = MCPProc->at(i);
-
                 //keep D0s and V0s from decays, conversions (a lot of compton or Ioni)
                 if( std::find(daughtersToKeep.begin(), daughtersToKeep.end(), PDGMother->at(i)) != daughtersToKeep.end() && hasOrigininTracker(spoint) && (process == "Decay" || process == "conv") ) {
                     std::cout << "Keeping D0 or V0" << std::endl;
                     std::cout << "Index " << i << " TrkID " << MCPTrkID->at(i) << " pdg " << PDG->at(i) << " mother pdg " << PDGMother->at(i);
-                    std::cout << " process " << process << std::endl;
+                    std::cout << " process " << process << " endprocess " << endprocess << std::endl;
                     std::cout << " Start point X: " << spoint.X() << " Y: " << spoint.Y() << " Z: " << spoint.Z() << std::endl;
                     std::cout << " End point X: " << epoint.X() << " Y: " << epoint.Y() << " Z: " << epoint.Z() << std::endl;
+                    std::cout << " Origin in tracker " << hasOrigininTracker(spoint) << std::endl;
+                    std::cout << " Decayed in Calo " << hasDecayedinCalo(epoint) << std::endl;
                     IndexesToKeep.push_back(i);
                 }
                 //check for backscatter
                 else if( isBackscatter(spoint, epoint) ) {
                     std::cout << "Keeping Backscatter" << std::endl;
                     std::cout << "Index " << i << " TrkID " << MCPTrkID->at(i) << " pdg " << PDG->at(i) << " mother pdg " << PDGMother->at(i);
-                    std::cout << " process " << process << std::endl;
+                    std::cout << " process " << process << " endprocess " << endprocess << std::endl;
                     std::cout << " Start point X: " << spoint.X() << " Y: " << spoint.Y() << " Z: " << spoint.Z() << std::endl;
                     std::cout << " End point X: " << epoint.X() << " Y: " << epoint.Y() << " Z: " << epoint.Z() << std::endl;
                     std::cout << " Origin in tracker " << hasOrigininTracker(spoint) << std::endl;
+                    std::cout << " Decayed in Calo " << hasDecayedinCalo(epoint) << std::endl;
                     IndexesToKeep.push_back(i);
                 }
                 //if Bremsstrahlung photon
                 else if ( isBremsstrahlung(spoint, PDG->at(i), PDGMother->at(i)) && process == "eBrem" ) {
                     std::cout << "Keeping Bremsstrahlung" << std::endl;
                     std::cout << "Index " << i << " TrkID " << MCPTrkID->at(i) << " pdg " << PDG->at(i) << " mother pdg " << PDGMother->at(i);
-                    std::cout << " process " << process << std::endl;
+                    std::cout << " process " << process << " endprocess " << endprocess << std::endl;
                     std::cout << " Start point X: " << spoint.X() << " Y: " << spoint.Y() << " Z: " << spoint.Z() << std::endl;
                     std::cout << " End point X: " << epoint.X() << " Y: " << epoint.Y() << " Z: " << epoint.Z() << std::endl;
                     std::cout << " Origin in tracker " << hasOrigininTracker(spoint) << std::endl;
+                    std::cout << " Decayed in Calo " << hasDecayedinCalo(epoint) << std::endl;
                     IndexesToKeep.push_back(i);
                 }
                 else {
@@ -348,8 +353,16 @@ void MCP_Skimmer::SkimMCParticle()
             }
 
             //keep only primaries
-            if(MCPProc->at(i) == "primary")
-            IndexesToKeep.push_back(i);
+            if(MCPProc->at(i) == "primary"){
+                std::cout << "Keeping Primary particle" << std::endl;
+                std::cout << "Index " << i << " TrkID " << MCPTrkID->at(i) << " pdg " << PDG->at(i) << " mother pdg " << PDGMother->at(i);
+                std::cout << " process " << process << " endprocess " << endprocess << std::endl;
+                std::cout << " Start point X: " << spoint.X() << " Y: " << spoint.Y() << " Z: " << spoint.Z() << std::endl;
+                std::cout << " End point X: " << epoint.X() << " Y: " << epoint.Y() << " Z: " << epoint.Z() << std::endl;
+                std::cout << " Origin in tracker " << hasOrigininTracker(spoint) << std::endl;
+                std::cout << " Decayed in Calo " << hasDecayedinCalo(epoint) << std::endl;
+                IndexesToKeep.push_back(i);
+            }
         }
 
 


### PR DESCRIPTION
Implemented first version for the mcp skimmer
- Creates a map between kids and original mother for all particles
- Keep only primaries, D0s and V0s (decays and conversions), Bremsstrahlung photons, backscatters from calo to tracker